### PR TITLE
Add CLI chatbot example

### DIFF
--- a/samples-app/README.md
+++ b/samples-app/README.md
@@ -1,0 +1,21 @@
+# Samples App
+
+This directory contains a minimal command line chatbot using the
+[Strands Agents](https://github.com/strands-agents/sdk-python) SDK with
+OpenAI.
+
+```bash
+# Install the SDK with the OpenAI extra
+pip install -e .[openai]
+```
+
+Set your OpenAI API key in the `OPENAI_API_KEY` environment variable and run the chatbot:
+
+Optionally set `OPENAI_MODEL_ID` to choose a different model (defaults to `gpt-3.5-turbo`).
+
+```bash
+export OPENAI_API_KEY="sk-..."
+python samples-app/chatbot.py
+```
+
+Use `CTRL-D` or type `exit` to quit the session.

--- a/samples-app/chatbot.py
+++ b/samples-app/chatbot.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+"""Simple CLI chatbot using the Strands SDK with OpenAI."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Allow running without installing the package
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from strands import Agent
+from strands.models import OpenAIModel
+
+
+def main() -> None:
+    """Run a simple CLI chatbot using OpenAI."""
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable not set")
+
+    model_id = os.getenv("OPENAI_MODEL_ID", "gpt-3.5-turbo")
+    model = OpenAIModel(model_id=model_id, client_args={"api_key": api_key})
+    agent = Agent(model=model)
+
+    print("Strands CLI Chatbot (OpenAI)")
+    print(f"Using model: {model_id}\n")
+    print("Type 'exit' or press Ctrl-D to quit.\n")
+
+    while True:
+        try:
+            user_input = input("You: ")
+        except EOFError:
+            print()
+            break
+
+        if user_input.strip().lower() in {"exit", "quit"}:
+            break
+
+        result = agent(user_input)
+        print(f"Agent: {str(result).strip()}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `samples-app` directory with README instructions
- provide `chatbot.py` for a simple OpenAI-powered CLI example
- document OPENAI env variables and model selection

## Testing
- `ruff check samples-app/chatbot.py`
- ❌ `hatch test` (failed: command not found)
- ❌ `hatch run test-integ` (failed: command not found)
- ❌ `python samples-app/chatbot.py` (failed: ModuleNotFoundError: No module named 'opentelemetry')

------
https://chatgpt.com/codex/tasks/task_e_684912c4131c832fab3b39ccfc157271